### PR TITLE
Implement Algolia Docsearch

### DIFF
--- a/docs/AlgoliaSearch.client.ts
+++ b/docs/AlgoliaSearch.client.ts
@@ -1,0 +1,6 @@
+document.body.addEventListener('keydown', (event: KeyboardEvent) => {
+  if (event.key === 'k' && event.ctrlKey) {
+    event.preventDefault()
+    document.getElementById('search')?.focus()
+  }
+})

--- a/docs/AlgoliaSearch.css
+++ b/docs/AlgoliaSearch.css
@@ -1,0 +1,22 @@
+.search-container {
+  position: fixed;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  padding: 20px;
+  z-index: 100;
+}
+.searchbox {
+  position: relative;
+  border-radius: 5px;
+  padding: 10px 15px;
+  margin: 0.67rem;
+  outline: none;
+  border-radius: 5px;
+  background: white;
+}
+
+.searchbox:focus {
+  outline: none;
+  border-radius: 5px;
+}

--- a/docs/AlgoliaSearch.tsx
+++ b/docs/AlgoliaSearch.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+export const AlgoliaSearch = () => {
+  return (
+    <div className="search-container">
+      <input type="text" id="search" placeholder="Search..." className="searchbox" />
+    </div>
+  )
+}

--- a/docs/PageLayout.tsx
+++ b/docs/PageLayout.tsx
@@ -3,6 +3,7 @@ import { Navigation } from './Navigation'
 import type { Heading } from './processPageContext'
 import { MobileHeader } from './MobileHeader'
 import { EditPageNote } from './EditPageNote'
+import { AlgoliaSearch } from './AlgoliaSearch'
 /* Won't work this this file is loaded only on the server
 import './PageLayout.css'
 */
@@ -23,20 +24,23 @@ function PageLayout({
 }) {
   const { headingsWithSubHeadings, isLandingPage, pageTitle } = pageContext
   return (
-    <div
-      style={{
-        display: 'flex',
-      }}
-    >
-      <Navigation headingsWithSubHeadings={headingsWithSubHeadings} urlPathname={pageContext.urlPathname} />
-      <div id="page-container" className={isLandingPage ? '' : 'doc-page'}>
-        <MobileHeader />
-        <div id="page-content">
-          {pageTitle && <h1>{pageTitle}</h1>}
-          {children}
-          {!isLandingPage && <EditPageNote pageContext={pageContext} />}
+    <>
+      <AlgoliaSearch />
+      <div
+        style={{
+          display: 'flex',
+        }}
+      >
+        <Navigation headingsWithSubHeadings={headingsWithSubHeadings} urlPathname={pageContext.urlPathname} />
+        <div id="page-container" className={isLandingPage ? '' : 'doc-page'}>
+          <MobileHeader />
+          <div id="page-content">
+            {pageTitle && <h1>{pageTitle}</h1>}
+            {children}
+            {!isLandingPage && <EditPageNote pageContext={pageContext} />}
+          </div>
         </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/docs/_default.page.client.ts
+++ b/docs/_default.page.client.ts
@@ -3,7 +3,8 @@ import './css/index.css'
 import './autoScrollNav'
 import './installSectionUrlHashs'
 import './Navigation.client'
-
+import './AlgoliaSearch.client'
+import './AlgoliaSearch.css'
 /*
 export { setClientFrame }
 function setClientFrame({assets}: {assets: string[]}) {

--- a/docs/_default.page.server.tsx
+++ b/docs/_default.page.server.tsx
@@ -29,9 +29,18 @@ function render(pageContext: PageContextOriginal) {
         <title>${pageContext.meta.title}</title>
         ${descriptionTag}
         <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
       </head>
       <body>
         <div id="page-view">${dangerouslySkipEscape(pageHtml)}</div>
+        <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+        <script type="text/javascript"> docsearch({
+        apiKey: '7d2798346ba008ae4902b49b097b6e6a',
+        indexName: 'vite-pluginssr',
+        inputSelector: '#search',
+        debug: false // Set debug to true if you want to inspect the dropdown
+        });
+        </script>
       </body>
     </html>`
 }

--- a/docs/_default.page.server.tsx
+++ b/docs/_default.page.server.tsx
@@ -35,8 +35,8 @@ function render(pageContext: PageContextOriginal) {
         <div id="page-view">${dangerouslySkipEscape(pageHtml)}</div>
         <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
         <script type="text/javascript"> docsearch({
-        apiKey: '7d2798346ba008ae4902b49b097b6e6a',
-        indexName: 'vite-pluginssr',
+        apiKey: '${pageContext.meta.algolia.apiKey}',
+        indexName: '${pageContext.meta.algolia.indexName}',
         inputSelector: '#search',
         debug: false // Set debug to true if you want to inspect the dropdown
         });

--- a/docs/frame.ts
+++ b/docs/frame.ts
@@ -13,6 +13,10 @@ type Frame = {
     twitterProfile: string
   }
   logoUrl: string
+  algolia: {
+    apiKey: string
+    indexName: string
+  }
   headings: HeadingDefinition[]
   headingsWithoutLink: HeadingWithoutLink[]
   navHeaderMobile: React.ReactNode

--- a/docs/processPageContext.ts
+++ b/docs/processPageContext.ts
@@ -23,12 +23,13 @@ function processPageContext(pageContext: PageContextOriginal) {
   const activeHeading = findActiveHeading(headings, headingsWithoutLink, pageContext)
   const headingsWithSubHeadings = getHeadingsWithSubHeadings(headings, pageContext, activeHeading)
   const { title, isLandingPage, pageTitle } = getMetaData(headingsWithoutLink, activeHeading, pageContext)
-  const { logoUrl } = getFrame()
+  const { logoUrl, algolia } = getFrame()
   const pageContextAdded = {}
   objectAssign(pageContextAdded, {
     meta: {
       title,
       logoUrl,
+      algolia
     },
     headings,
     headingsWithSubHeadings,


### PR DESCRIPTION
This adds in the search functionality discussed in [#216](https://github.com/brillout/vite-plugin-ssr/issues/216). It uses the Algolia js and css provided in the snippet. 

Users can also press ctrl+k to focus on the search input like most sites implement today. 

The styling is fairly basic other than what Algolia provide, feel free to change. 